### PR TITLE
Add basic auth support

### DIFF
--- a/library/kong_api.py
+++ b/library/kong_api.py
@@ -28,7 +28,7 @@ import json, requests, os
 
 class KongAPI:
 
-    def __init__(self, base_url, auth_username, auth_password):
+    def __init__(self, base_url, auth_username=None, auth_password=None):
         self.base_url = base_url
         if auth_username is not None and auth_password is not None:
             self.auth = (auth_username, auth_password)
@@ -120,7 +120,7 @@ class ModuleHelper:
             if value is not None:
                 data[field] = value
 
-        return (url, auth_user, auth_password, data, state)
+        return (url, data, state, auth_user, auth_password)
 
     def get_response(self, response, state):
 
@@ -153,7 +153,7 @@ def main():
 
     global module # might not need this
     module = helper.get_module()  
-    base_url, auth_user, auth_password, data, state = helper.prepare_inputs(module)
+    base_url, data, state, auth_user, auth_password = helper.prepare_inputs(module)
 
     api = KongAPI(base_url, auth_user, auth_password)
     if state == "present":

--- a/library/kong_consumer.py
+++ b/library/kong_consumer.py
@@ -4,12 +4,15 @@ import requests
 
 class KongConsumer:
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, auth_username=None, auth_password=None):
         self.base_url = "{}/consumers" . format(base_url)
-        
+        if auth_username is not None and auth_password is not None:
+            self.auth = (auth_username, auth_password)
+        else:
+            self.auth = None
 
     def list(self):
-    	return requests.get(self.base_url)
+    	return requests.get(self.base_url, auth=self.auth)
 
     def add(self, username=None, custom_id=None):
     	
@@ -22,17 +25,17 @@ class KongConsumer:
     	if custom_id is not None:
     		data['custom_id'] = custom_id
 
-    	return requests.post(self.base_url, data)
+    	return requests.post(self.base_url, data, auth=self.auth)
 
     def delete(self, id):
     	url = "{}/{}" . format (self.base_url, id)
-    	return requests.delete(url)
+    	return requests.delete(url, auth=self.auth)
 
     def configure_for_plugin(self, username_or_id, api, data):
         """This could possibly go in it's own plugin"""
 
         url = "{}/{}/{}" . format (self.base_url, username_or_id, api)
-        return requests.post(url, data)
+        return requests.post(url, data, auth=self.auth)
 
 class ModuleHelper:
     
@@ -40,6 +43,8 @@ class ModuleHelper:
 
         args = dict(
             kong_admin_uri = dict(required=True, type='str'),
+            kong_admin_username = dict(required=False, type='str'),
+            kong_admin_password = dict(required=False, type='str'),
             username = dict(required=False, type='str'),
             custom_id = dict(required=False, type='str'),
             state = dict(required=False, default="present", choices=['present', 'absent', 'list', 'configure'], type='str'),    
@@ -50,13 +55,15 @@ class ModuleHelper:
 
     def prepare_inputs(self, module):
         url = module.params['kong_admin_uri']
+        auth_user = module.params['kong_admin_username']
+        auth_password = module.params['kong_admin_password']
         state = module.params['state']    
         username = module.params.get('username', None)
         custom_id = module.params.get('custom_id', None)
         data = module.params.get('data', None)
         api_name = module.params.get('api_name', None)
         
-        return (url, username, custom_id, state, api_name, data)
+        return (url, username, custom_id, state, api_name, data, auth_user, auth_password)
 
     def get_response(self, response, state):
 
@@ -79,9 +86,9 @@ def main():
 
     global module # might not need this
     module = helper.get_module()  
-    base_url, username, id, state, api_name, data = helper.prepare_inputs(module)
+    base_url, username, id, state, api_name, data, auth_user, auth_password = helper.prepare_inputs(module)
 
-    api = KongConsumer(base_url)
+    api = KongConsumer(base_url, auth_user, auth_password)
     if state == "present":
         response = api.add(username, id)
     if state == "absent":
@@ -90,9 +97,14 @@ def main():
         response = api.configure_for_plugin(username, api_name, data)
     if state == "list":
         response = api.list()
-    
-    has_changed, meta = helper.get_response(response, state)
-    module.exit_json(changed=has_changed, meta=meta)
+
+    if response.status_code == 401:
+        module.fail_json(msg="Please specify kong_admin_username and kong_admin_password", meta=response.json())
+    elif response.status_code == 403:
+        module.fail_json(msg="Please check kong_admin_username and kong_admin_password", meta=response.json())
+    else:
+        has_changed, meta = helper.get_response(response, state)
+        module.exit_json(changed=has_changed, meta=meta)
 
 
 from ansible.module_utils.basic import *

--- a/library/kong_plugin.py
+++ b/library/kong_plugin.py
@@ -4,7 +4,7 @@ import requests
 
 class KongPlugin:
 
-    def __init__(self, base_url, auth_username, auth_password, api_name):
+    def __init__(self, base_url, api_name, auth_username=None, auth_password=None):
         self.base_url = "{}/apis/{}/plugins" . format(base_url, api_name)
         if auth_username is not None and auth_password is not None:
             self.auth = (auth_username, auth_password)
@@ -78,7 +78,7 @@ class ModuleHelper:
             "config": module.params['config']        
         }
 
-        return (url, auth_user, auth_password, api_name, data, state)
+        return (url, api_name, data, state, auth_user, auth_password)
 
     def get_response(self, response, state):
 
@@ -106,12 +106,12 @@ def main():
     helper = ModuleHelper()
 
     global module # might not need this
-    module = helper.get_module()  
-    base_url, auth_user, auth_password, api_name, data, state = helper.prepare_inputs(module)
+    module = helper.get_module()
+    base_url, api_name, data, state, auth_user, auth_password = helper.prepare_inputs(module)
 
     method_to_call = state_to_method.get(state)
 
-    api = KongPlugin(base_url, auth_user, auth_password, api_name)
+    api = KongPlugin(base_url, api_name, auth_user, auth_password)
     if state == "present":
         response = api.add_or_update(**data)
     if state == "absent":

--- a/library/kong_plugin.py
+++ b/library/kong_plugin.py
@@ -4,13 +4,17 @@ import requests
 
 class KongPlugin:
 
-    def __init__(self, base_url, api_name):
+    def __init__(self, base_url, auth_username, auth_password, api_name):
         self.base_url = "{}/apis/{}/plugins" . format(base_url, api_name)
+        if auth_username is not None and auth_password is not None:
+            self.auth = (auth_username, auth_password)
+        else:
+            self.auth = None
         self.api = api_name
 
     def list(self):
         
-        return requests.get(self.base_url)
+        return requests.get(self.base_url, auth=self.auth)
 
     def _get_plugin_id(self, name, plugins_list):
         """Scans the list of plugins for an ID. 
@@ -36,15 +40,15 @@ class KongPlugin:
 
         plugin_id = self._get_plugin_id(name, plugins_list)
         if plugin_id is None:            
-            return requests.post(self.base_url, data)
+            return requests.post(self.base_url, data, auth=self.auth)
         else:
             url = "{}/{}" . format (self.base_url, plugin_id)
-            return requests.patch(url, data)
+            return requests.patch(url, data, auth=self.auth)
 
     def delete(self, id):
 
         url = "{}/{}" . format (self.base_url, id)
-        return requests.delete(url)
+        return requests.delete(url, auth=self.auth)
 
 
 class ModuleHelper:
@@ -53,6 +57,8 @@ class ModuleHelper:
 
         args = dict(
             kong_admin_uri = dict(required=True, type='str'),
+            kong_admin_username = dict(required=False, type='str'),
+            kong_admin_password = dict(required=False, type='str'),
             api_name = dict(required=False, type='str'),
             plugin_name = dict(required=False, type='str'),
             plugin_id = dict(required=False, type='str'),
@@ -63,6 +69,8 @@ class ModuleHelper:
 
     def prepare_inputs(self, module):
         url = module.params['kong_admin_uri']
+        auth_user = module.params['kong_admin_username']
+        auth_password = module.params['kong_admin_password']
         api_name = module.params['api_name']
         state = module.params['state']    
         data = {
@@ -70,7 +78,7 @@ class ModuleHelper:
             "config": module.params['config']        
         }
 
-        return (url, api_name, data, state)
+        return (url, auth_user, auth_password, api_name, data, state)
 
     def get_response(self, response, state):
 
@@ -99,20 +107,25 @@ def main():
 
     global module # might not need this
     module = helper.get_module()  
-    base_url, api_name, data, state = helper.prepare_inputs(module)
+    base_url, auth_user, auth_password, api_name, data, state = helper.prepare_inputs(module)
 
     method_to_call = state_to_method.get(state)
 
-    api = KongPlugin(base_url, api_name)
+    api = KongPlugin(base_url, auth_user, auth_password, api_name)
     if state == "present":
         response = api.add_or_update(**data)
     if state == "absent":
         response = api.delete(module.params['plugin_id'])
     if state == "list":
         response = api.list()
-    
-    has_changed, meta = helper.get_response(response, state)
-    module.exit_json(changed=has_changed, meta=meta)
+
+    if response.status_code == 401:
+        module.fail_json(msg="Please specify kong_admin_username and kong_admin_password", meta=response.json())
+    elif response.status_code == 403:
+        module.fail_json(msg="Please check kong_admin_username and kong_admin_password", meta=response.json())
+    else:
+        has_changed, meta = helper.get_response(response, state)
+        module.exit_json(changed=has_changed, meta=meta)
 
 
 from ansible.module_utils.basic import *

--- a/library/test_kong.py
+++ b/library/test_kong.py
@@ -22,6 +22,8 @@ class ModuleHelperTestCase(unittest.TestCase):
 		self.module = MockModule()
 		self.module.params = {
 			"kong_admin_uri": mock_kong_admin_url,
+			"kong_admin_username": None,
+			"kong_admin_password": None,
             "name": "mockbin", 
             "request_host": "mockbin.com", 
             "request_path": "/mockbin", 
@@ -33,7 +35,7 @@ class ModuleHelperTestCase(unittest.TestCase):
 
 	def test_prepare_inputs(self):
 		
-		url, data, state = self.helper.prepare_inputs(self.module)
+		url, data, state, auth_user, auth_password = self.helper.prepare_inputs(self.module)
 
 		assert url == mock_kong_admin_url
 		assert state == "present"
@@ -75,7 +77,7 @@ class MainTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_add(self, mock_prepare_inputs, mock_module, mock_add, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, {}, "present")
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, {}, "present", None, None)
 		mock_get_response.return_value = (True, {})
 		main()
 
@@ -88,7 +90,7 @@ class MainTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_delete(self, mock_prepare_inputs, mock_module, mock_delete, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, {}, "absent")
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, {}, "absent", None, None)
 		mock_get_response.return_value = (True, {})
 		main()
 
@@ -101,7 +103,7 @@ class MainTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_add(self, mock_prepare_inputs, mock_module, mock_list, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, {}, "list")
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, {}, "list", None, None)
 		mock_get_response.return_value = (True, {})
 		main()
 

--- a/library/test_kong_consumer.py
+++ b/library/test_kong_consumer.py
@@ -74,7 +74,7 @@ class ModuleHelperTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_add(self, mock_prepare_inputs, mock_module, mock_add, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "present", None, None)
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "present", None, None, None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 
@@ -87,7 +87,7 @@ class ModuleHelperTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_delete(self, mock_prepare_inputs, mock_module, mock_delete, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "absent", None, None)
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "absent", None, None, None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 
@@ -100,7 +100,7 @@ class ModuleHelperTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_list(self, mock_prepare_inputs, mock_module, mock_list, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "list", None, None)
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "list", None, None, None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 
@@ -113,7 +113,7 @@ class ModuleHelperTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_list(self, mock_prepare_inputs, mock_module, mock_configure_for_plugin, mock_exit_json, mock_get_response):
 
-		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "configure", "auth-key", {"key": "123"})
+		mock_prepare_inputs.return_value = (mock_kong_admin_url, "1","joesoap", "configure", "auth-key", {"key": "123"}, None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 
@@ -130,10 +130,12 @@ class ModuleHelperTestCase(unittest.TestCase):
 		mock_module = MockModule()
 		mock_module.params = {
 			'kong_admin_uri': mock_kong_admin_url,
+			'kong_admin_username': None,
+			'kong_admin_password': None,
 			'state': 'present',
 			'username': 'joesoap',
 		}
-		url, username, id, state, api_name, data = self.helper.prepare_inputs(mock_module)
+		url, username, id, state, api_name, data, auth_username, auth_password = self.helper.prepare_inputs(mock_module)
 
 		assert url == mock_kong_admin_url
 		assert state == 'present'

--- a/library/test_kong_plugin.py
+++ b/library/test_kong_plugin.py
@@ -105,15 +105,15 @@ class MainTestCase(unittest.TestCase):
 	        	"foo": "bar"
 	        }
 		}
-	
+
 	@mock.patch.object(ModuleHelper, 'get_response')
 	@mock.patch.object(AnsibleModule, 'exit_json')
 	@mock.patch.object(KongPlugin, 'add_or_update')
 	@mock.patch.object(ModuleHelper, 'get_module')
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_present(self, mock_prepare_inputs, mock_module, mock_add_or_update, mock_exit_json, mock_get_response):
-		
-		mock_prepare_inputs.return_value = ("","mockbin", {}, "present")
+
+		mock_prepare_inputs.return_value = ("","mockbin", {}, "present", None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 
@@ -125,8 +125,8 @@ class MainTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'get_module')
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_delete(self, mock_prepare_inputs, mock_module, mock_delete, mock_exit_json, mock_get_response):
-		
-		mock_prepare_inputs.return_value = ("","mockbin", {}, "absent")
+
+		mock_prepare_inputs.return_value = ("","mockbin", {}, "absent", None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 
@@ -138,8 +138,8 @@ class MainTestCase(unittest.TestCase):
 	@mock.patch.object(ModuleHelper, 'get_module')
 	@mock.patch.object(ModuleHelper, 'prepare_inputs')
 	def test_main_list(self, mock_prepare_inputs, mock_module, mock_list, mock_exit_json, mock_get_response):
-		
-		mock_prepare_inputs.return_value = ("","mockbin", {}, "list")
+
+		mock_prepare_inputs.return_value = ("","mockbin", {}, "list", None, None)
 		mock_get_response.return_value = (True, requests.Response())
 		main()
 


### PR DESCRIPTION
Hi there,

I found this Ansible module for Kong from your blog article: http://blog.toast38coza.me/kong-up-and-running-part-2-defining-our-api-gateway-with-ansible/

However, I also needed support for basic auth, since my Kong instance is configured with basic auth on the Kong admin api.

This pull request adds support for basic auth via two new module args, `kong_admin_username` and `kong_admin_password`.

Thanks,

Alex.